### PR TITLE
Remove type annotation in `delay_distance`

### DIFF
--- a/src/nlts.jl
+++ b/src/nlts.jl
@@ -155,8 +155,7 @@ end
     abs(R[m+k][1] - R[n+k][1])
 end
 
-@inline @inbounds function delay_distance(di::Euclidean,
-    R::Reconstruction{D, T, τ}, m, n, k) where {D, T, τ}
+@inline @inbounds function delay_distance(di::Euclidean, R, m, n, k)
     return norm(R[m+k] - R[n+k])
 end
 

--- a/src/nlts.jl
+++ b/src/nlts.jl
@@ -13,7 +13,7 @@ export Cityblock, Euclidean
 
 """
 ```julia
-numericallyapunov(R::Reconstruction, ks;  refstates, w, distance, method)
+numericallyapunov(R::AbstractDataset, ks;  refstates, w, distance, method)
 ```
 Return `E = [E(k) for k ∈ ks]`, where `E(k)` is the average logarithmic distance for
 nearby states that are evolved in time for `k` steps (`k` must be integer).
@@ -26,7 +26,9 @@ nearby states that are evolved in time for `k` steps (`k` must be integer).
   that the algorithm is applied for all state indices contained in `refstates`.
 * `w::Int = round(Int, mean(R.delay))` : The Theiler window, which determines
   whether points are separated enough in time to be considered separate trajectories
-  (see [1]). Defaults to the mean delay time.
+  (see [1]). Defaults to the mean delay time. If you give a `Dataset` instead
+  of a `Reconstruction` in the place of `R`, you *must* provide the Theiler window
+  (you can give `w=typemax(Int)` if it does not apply to your case).
 * `method::AbstractNeighborhood = FixedMassNeighborhood(1)` : The method to
   be used when evaluating the neighborhood of each reference state. See
   [`AbstractNeighborhood`](@ref) or [`neighborhood`](@ref) for more info.
@@ -36,7 +38,7 @@ nearby states that are evolved in time for `k` steps (`k` must be integer).
 
 
 ## Description
-If the reconstruction
+If the dataset/reconstruction
 exhibits exponential divergence of nearby states, then it should clearly hold
 ```math
 E(k) \\approx \\lambda\\Delta t k + E(0)

--- a/src/nlts.jl
+++ b/src/nlts.jl
@@ -73,20 +73,20 @@ of the reconstruction `R`(distance ``d_F`` in ref. [1]).
 
 [2] : Kantz, H., Phys. Lett. A **185**, pp 77–87 (1994)
 """
-function numericallyapunov(R::AbstractReconstruction{D, T, τ}, ks;
+function numericallyapunov(R::AbstractDataset{D, T}, ks;
                            refstates = 1:(length(R) - ks[end]),
                            w = round(Int, mean(R.delay)),
                            distance = Cityblock(),
-                           method = FixedMassNeighborhood(1)) where {D, T, τ}
+                           method = FixedMassNeighborhood(1)) where {D, T}
     Ek = numericallyapunov(R, ks, refstates, w, distance, method)
 end
 
-function numericallyapunov(R::AbstractReconstruction{D, T, τ},
+function numericallyapunov(R::AbstractDataset{D, T},
                            ks::AbstractVector{Int},
                            ℜ::AbstractVector{Int},
                            w::Int,
                            distance::Metric,
-                           method::AbstractNeighborhood) where {D, T, τ}
+                           method::AbstractNeighborhood) where {D, T}
 
     # ℜ = \Re<tab> = set of indices that have the points that one finds neighbors.
     # n belongs in ℜ and R[n] is the "reference state".

--- a/test/nlts_tests.jl
+++ b/test/nlts_tests.jl
@@ -43,21 +43,21 @@ println("\nTesting nonlinear timeseries analysis...")
                 end
             end
         end
-        @testset "Multidim Multitime R" begin
-            ds = Systems.towel()
-            data = trajectory(ds, 10000)
-
-            taus = [0 0; 2 3; 4 6; 6 8]
-            data2 = data[:, 1:2]
-            R = Reconstruction(data2, 4, taus)
-
-            ks = 1:20
-            E = numericallyapunov(R, ks,
-            refstates = 1:1000, distance=Cityblock(), method=FixedMassNeighborhood(1))
-            λ = linear_region(ks, E)[2]
-            test_value(λ, 0.3, 0.5)
-        end
     end
+end
+@testset "Multidim Multitime R" begin
+    ds = Systems.towel()
+    data = trajectory(ds, 10000)
+
+    taus = [0 0; 2 3; 4 6; 6 8]
+    data2 = data[:, 1:2]
+    R = Reconstruction(data2, 4, taus)
+
+    ks = 1:20
+    E = numericallyapunov(R, ks,
+    refstates = 1:1000, distance=Cityblock(), method=FixedMassNeighborhood(1))
+    λ = linear_region(ks, E)[2]
+    test_value(λ, 0.3, 0.5)
 end
 
 @testset "Broomhead-King" begin

--- a/test/nlts_tests.jl
+++ b/test/nlts_tests.jl
@@ -43,6 +43,20 @@ println("\nTesting nonlinear timeseries analysis...")
                 end
             end
         end
+        @testset "Multidim Multitime R" begin
+            ds = Systems.towel()
+            data = trajectory(ds, 10000)
+
+            taus = [0 0; 2 3; 4 6; 6 8]
+            data2 = data[:, 1:2]
+            R = Reconstruction(data2, 4, taus)
+
+            ks = 1:20
+            E = numericallyapunov(R, ks,
+            refstates = 1:1000, distance=Cityblock(), method=FixedMassNeighborhood(1))
+            λ = linear_region(ks, E)[2]
+            test_value(λ, 0.3, 0.5)
+        end
     end
 end
 


### PR DESCRIPTION
The type annotation prevented the use of `numericallyapunov` with multi-dimensional reconstructions.