### PR TITLE
Improved performance of non0hist

### DIFF
--- a/src/dimensions/entropies.jl
+++ b/src/dimensions/entropies.jl
@@ -50,7 +50,10 @@ function non0hist(ε::Real, data::AbstractDataset{D, T}) where {D, T<:Real}
     end
     push!(hist, count/L)
 
-    return collect(hist)
+    # Shrink histogram capacity to fit its size:
+    sizehint!(hist, length(hist))
+
+    return hist
 end
 
 

--- a/src/dimensions/entropies.jl
+++ b/src/dimensions/entropies.jl
@@ -11,11 +11,9 @@ size `ε` and return the sum-normalized histogram in an unordered 1D form,
 discarding all zero elements.
 
 ## Performances Notes
-This method is effecient in both memory
-and speed, because it uses a dictionary to collect the information of bins with
-elements, while it completely disregards empty bins. This allows
-computation of entropies of high-dimensional datasets and
-with small box sizes `ε` without memory overflow.
+This method has a linearithmic time complexity and a linear space complexity
+in `length(data)`. This allows computation of entropies of high-dimensional
+datasets and with small box sizes `ε` without memory overflow.
 
 Use e.g. `fit(Histogram, ...)` from
 [`StatsBase`](http://juliastats.github.io/StatsBase.jl/stable/) if you

--- a/src/dimensions/entropies.jl
+++ b/src/dimensions/entropies.jl
@@ -31,7 +31,7 @@ function non0hist(ε::Real, data::AbstractDataset{D, T}) where {D, T<:Real}
 
     # Map each datapoint to its bin edge and sort the resulting list:
     bins = map(point -> floor.(Int, (point - mini)/ε), data)
-    sort!(bins)
+    sort!(bins, alg=QuickSort)
 
     # Fill the histogram by counting consecutive equal bins:
     prev_bin = bins[1]


### PR DESCRIPTION
Here is my proposal to optimize `non0hist` and resolve #58 .

The approach here is to replace each data point by its respective bin and sort the resulting list.
The histogram is then generated by counting consecutive equal bins in the sorted list of bins.

Note that the function will fail for an empty dataset, just like the original one.
Maybe it would be better to check that the dataset is not empty (and also that ε > 0).

Here are the results of the benchmark mentionned in #58:
Before:
```
ε = 0.1
  27.732 ms (14 allocations: 14.95 KiB)
with entropy = 4.762599382598514
ε = 0.01
  33.068 ms (37 allocations: 3.05 MiB)
with entropy = 9.471958080074165
ε = 0.001
  44.876 ms (43 allocations: 12.48 MiB)
with entropy = 11.463669293018897
```
After:
```
ε = 0.1
  11.732 ms (9 allocations: 4.20 MiB)
with entropy = 4.762599382598511
ε = 0.01
  13.904 ms (10 allocations: 4.34 MiB)
with entropy = 9.47195808007418
ε = 0.001
  13.468 ms (10 allocations: 4.93 MiB)
with entropy = 11.463669293019212
```