### PR TITLE
Changed `e` to `Base.MathConstants.e`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ChaosTools"
 uuid = "608a59af-f2a3-5ad4-90b4-758bdf3122a7"
 repo = "https://github.com/JuliaDynamics/ChaosTools.jl.git"
-version = "1.15.0"
+version = "1.15.1"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/dimensions/entropies.jl
+++ b/src/dimensions/entropies.jl
@@ -60,14 +60,14 @@ end
 
 
 """
-    genentropy(α, ε::Real, dataset::AbstractDataset; base = e)
+    genentropy(α, ε::Real, dataset::AbstractDataset; base = Base.MathConstants.e)
 Compute the `α` order generalized (Rényi) entropy[^Rényi1960] of a dataset,
 by first partitioning it into boxes of length `ε` using [`non0hist`](@ref).
 
-    genentropy(α, εs::AbstractVector, dataset::AbstractDataset; base = e)
+    genentropy(α, εs::AbstractVector, dataset::AbstractDataset; base = Base.MathConstants.e)
 Same as `[genentropy(α, ε, dataset) for ε in εs]`.
 
-    genentropy(α, p::AbstractArray; base = e)
+    genentropy(α, p::AbstractArray; base = Base.MathConstants.e)
 Compute the entropy of an array of probabilities `p`, assuming that `p` is
 sum-normalized.
 
@@ -99,7 +99,7 @@ genentropy(α, ε, Dataset(matrix); base = base)
 genentropy(α::Real, ε::AbstractVector, X::AbstractDataset; base = Base.MathConstants.e) =
 [genentropy(α, e, X; base = base) for e in ε]
 
-function genentropy(α::Real, p::AbstractArray{T}; base = e) where {T<:Real}
+function genentropy(α::Real, p::AbstractArray{T}; base = Base.MathConstants.e) where {T<:Real}
     α < 0 && throw(ArgumentError("Order of generalized entropy must be ≥ 0."))
     if α ≈ 0
         return log(base, length(p)) #Hartley entropy, max-entropy
@@ -115,7 +115,7 @@ end
 
 
 """
-    permentropy(x::AbstractVector, order [, interval=1]; base = e)
+    permentropy(x::AbstractVector, order [, interval=1]; base = Base.MathConstants.e)
 
 Compute the permutation entropy[^Brandt2002] of given `order`
 from the `x` timeseries.


### PR DESCRIPTION
In some definitions of `genentropy` and `permentropy` Euler's number was written as `e` instead of `Base.MathConstants.e`.