### PR TITLE
`poincaresos` for existing Dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.18
+* `poincaresos` function now also works with input `Dataset` (and does linear interpolation between points sandwiching the dataset)
+
 # 1.17
 * `transit_time_statistics` deprecated in favor of `exit_entry_times`.
 * Added `mean_return_times` function for discrete systems.

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ChaosTools"
 uuid = "608a59af-f2a3-5ad4-90b4-758bdf3122a7"
 repo = "https://github.com/JuliaDynamics/ChaosTools.jl.git"
-version = "1.17.0"
+version = "1.18.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/orbitdiagrams/poincare.jl
+++ b/src/orbitdiagrams/poincare.jl
@@ -258,9 +258,10 @@ end
 #####################################################################################
 """
     poincaresos(A::Dataset, plane; kwargs...)
-Rettua
+Calculate the Poincaré surface of section of the given dataset with the given `plane`
+by performing linear interpolation betweeen points that sandwich the hyperplane.
 
-Keywords `direction, warning, idxs` are the same as above.
+Argument `plane` and keywords `direction, warning, idxs` are the same as above.
 """
 function poincaresos(A::Dataset, plane; direction = -1, warning = true, idxs = 1:size(A, 2))
     _check_plane(plane, size(A, 2))
@@ -299,8 +300,12 @@ end
 
 function interpolate_crossing(A, B, pc::PlaneCrossing{<:AbstractVector})
     # https://en.wikipedia.org/wiki/Line%E2%80%93plane_intersection
-    line = t -> A .+ (B .- A) .* t  # line equation, t ∈ [0, 1]
-    error("# TODO: Finish this")
+    n = @view pc.plane[1:end-1] # normal vector to hyperplane
+    i = findfirst(!iszero, pc.plane)
+    p₀ = zeros(length(A))
+    p₀[i] = pc.plane[end]/pc.plane[i] # p₀ is a point on the plane.
+    t = LinearAlgebra.dot(n, (p₀ .- A))/LinearAlgebra.dot((B .- A), n)
+    return A .+ (B .- A) .* t
 end
 
 function interpolate_crossing(A, B, pc::PlaneCrossing{<:Tuple})

--- a/src/orbitdiagrams/poincare.jl
+++ b/src/orbitdiagrams/poincare.jl
@@ -262,8 +262,8 @@ Rettua
 
 Keywords `direction, warning, idxs` are the same as above.
 """
-function poincaresos(A::Dataset, plane; direction = -1, warning = true, idxs = 1:D)
-    _check_plane(plane, D)
+function poincaresos(A::Dataset, plane; direction = -1, warning = true, idxs = 1:size(A, 2))
+    _check_plane(plane, size(A, 2))
     i = typeof(idxs) <: Int ? i : SVector{length(idxs), Int}(idxs...)
     planecrossing = PlaneCrossing(plane, direction > 0)
     data = poincaresos(A, planecrossing, i)
@@ -305,7 +305,7 @@ end
 
 function interpolate_crossing(A, B, pc::PlaneCrossing{<:Tuple})
     # https://en.wikipedia.org/wiki/Linear_interpolation
-    y₀ = A[pc[1]]; y₁ = B[pc[1]]; y = pc[2]
+    y₀ = A[pc.plane[1]]; y₁ = B[pc.plane[1]]; y = pc.plane[2]
     t = (y - y₀) / (y₁ - y₀) # linear interpolation with t₀ = 0, t₁ = 1
     return A .+ (B .- A) .* t
 end

--- a/src/orbitdiagrams/poincare.jl
+++ b/src/orbitdiagrams/poincare.jl
@@ -291,8 +291,21 @@ function poincaresos(A::Dataset, planecrossing::PlaneCrossing, j)
         end
         i == L && break
         # It is now guaranteed that A crosses hyperplane between i-1 and i
-        ucross = interpolate_crossing(A[i], A[i-1], planecrossing)
+        ucross = interpolate_crossing(A[i-1], A[i], planecrossing)
         push!(data, ucross[j])
     end
     return data
+end
+
+function interpolate_crossing(A, B, pc::PlaneCrossing{<:AbstractVector})
+    # https://en.wikipedia.org/wiki/Line%E2%80%93plane_intersection
+    line = t -> A .+ (B .- A) .* t  # line equation, t ∈ [0, 1]
+    error("# TODO: Finish this")
+end
+
+function interpolate_crossing(A, B, pc::PlaneCrossing{<:Tuple})
+    # https://en.wikipedia.org/wiki/Linear_interpolation
+    y₀ = A[pc[1]]; y₁ = B[pc[1]]; y = pc[2]
+    t = (y - y₀) / (y₁ - y₀) # linear interpolation with t₀ = 0, t₁ = 1
+    return A .+ (B .- A) .* t
 end

--- a/src/orbitdiagrams/poincare.jl
+++ b/src/orbitdiagrams/poincare.jl
@@ -269,6 +269,8 @@ end
 #####################################################################################
 # Poincare Section for Datasets (trajectories)                                      #
 #####################################################################################
+# TODO: Nice improvement would be to use cubic interpolation instead of linear,
+# using points i-2, i-1, i, i+1
 """
     poincaresos(A::Dataset, plane; kwargs...)
 Calculate the Poincaré surface of section of the given dataset with the given `plane`

--- a/src/orbitdiagrams/poincare.jl
+++ b/src/orbitdiagrams/poincare.jl
@@ -5,6 +5,33 @@ export poincaresos, produce_orbitdiagram, PlaneCrossing
 const ROOTS_ALG = A42()
 
 #####################################################################################
+#                               Hyperplane                                          #
+#####################################################################################
+"""
+    PlaneCrossing(plane, dir) → z
+Create a struct that can be called as a function `z(u)` and returns the signed distance
+of state `u` from the hyperplane represented by `z`. See [`poincaresos`](@ref) for
+the what `plane` can be (tuple or vector).
+"""
+struct PlaneCrossing{P}
+    plane::P
+    dir::Bool
+end
+function (hp::PlaneCrossing{P})(u::AbstractVector) where {P<:Tuple}
+    @inbounds x = u[hp.plane[1]] - hp.plane[2]
+    hp.dir ? x : -x
+end
+function (hp::PlaneCrossing{P})(u::AbstractVector) where {P<:AbstractVector}
+    x = zero(eltype(u))
+    D = length(u)
+    @inbounds for i in 1:D
+        x += u[i]*hp.plane[i]
+    end
+    @inbounds x -= hp.plane[D+1]
+    hp.dir ? x : -x
+end
+
+#####################################################################################
 #                               Poincare Section                                    #
 #####################################################################################
 """
@@ -87,25 +114,6 @@ end
 
 const PSOS_ERROR =
 "the Poincaré surface of section did not have any points!"
-
-struct PlaneCrossing{P}
-    plane::P
-    dir::Bool
-end
-PlaneCrossing(p::P, b) where {P} = PlaneCrossing{P}(p, b)
-function (hp::PlaneCrossing{P})(u::AbstractVector) where {P<:Tuple}
-    @inbounds x = u[hp.plane[1]] - hp.plane[2]
-    hp.dir ? x : -x
-end
-function (hp::PlaneCrossing{P})(u::AbstractVector) where {P<:AbstractVector}
-    x = zero(eltype(u))
-    D = length(u)
-    @inbounds for i in 1:D
-        x += u[i]*hp.plane[i]
-    end
-    @inbounds x -= hp.plane[D+1]
-    hp.dir ? x : -x
-end
 
 function poincaresos(integ, planecrossing, tfinal, Ttr, j, rootkw)
 

--- a/test/orbitdiagrams/poincare_tests.jl
+++ b/test/orbitdiagrams/poincare_tests.jl
@@ -93,3 +93,15 @@ end
 
   end
 end
+
+@testset "PoincareSOS of trajectory" begin
+    ds = Systems.lorenz()
+    tr = trajectory(ds, 1000.0; Ttr = 10.0)
+    psos = poincaresos(tr, (2, 0.0))
+    @test all(abs.(psos[:, 2]) .≤ 1e-15)
+    psos = poincaresos(tr, [0, 1.0, 0, 0])
+    @test all(abs.(psos[:, 2]) .≤ 1e-15)
+    psos = poincaresos(tr, [1.0, 1.0, 0, 0])
+    g = generalized_dim(0.0, psos)
+    @test g ≤ 1
+end


### PR DESCRIPTION
Currently `poincaresos` takes in a `DynamicalSystem` and calculates the Poincare section with high precision using high order interpolation from DifferentialEquations.jl. However if one has experimental measurements and unknown `f` then they can't use this.

This simple addition allows for linear interpolation in existing datasets.

(wip: need to get the equation down for general hyperplane, currently works for `(j, r)` type of plane).