### PR TITLE
Bugfix for `molteno_dim`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ChaosTools"
 uuid = "608a59af-f2a3-5ad4-90b4-758bdf3122a7"
 repo = "https://github.com/JuliaDynamics/ChaosTools.jl.git"
-version = "1.24.0"
+version = "1.24.1"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/dimensions/molteno.jl
+++ b/src/dimensions/molteno.jl
@@ -27,7 +27,7 @@ function molteno_dim(data; k0 = 10, α = nothing, q=1.0, base = ℯ)
         @warn "Keyword `α` is deprecated in favor of `q`."
         q = α
     end
-    boxes, εs = molteno_boxing(data, k0)
+    boxes, εs = molteno_boxing(data; k0 = k0)
     dd = genentropy.(boxes; q, base)
     return linear_region(-log.(base, εs), dd)[2]
 end

--- a/src/dimensions/molteno.jl
+++ b/src/dimensions/molteno.jl
@@ -27,7 +27,7 @@ function molteno_dim(data; k0 = 10, α = nothing, q=1.0, base = ℯ)
         @warn "Keyword `α` is deprecated in favor of `q`."
         q = α
     end
-    boxes, εs = molteno_boxing(data; k0 = k0)
+    boxes, εs = molteno_boxing(data; k0)
     dd = genentropy.(boxes; q, base)
     return linear_region(-log.(base, εs), dd)[2]
 end


### PR DESCRIPTION
`k0` is a keyword argument for `molteno_boxing`. `molteno_dim` assumed it was an argument. The usage in `molteno_dim` was corrected.