### PR TITLE
Fix attractors

### DIFF
--- a/src/basins/compute_ba.jl
+++ b/src/basins/compute_ba.jl
@@ -1,6 +1,6 @@
 export draw_basin!, basins_map2D, basins_general
 
-mutable struct BasinInfo{F,T,Q}
+mutable struct BasinInfo{F,N,T,Q}
     basin::Matrix{Int16}
     xg::F
     yg::F
@@ -16,7 +16,7 @@ mutable struct BasinInfo{F,T,Q}
     prev_bas::Int
     prev_step::Int
     step::Int
-    attractors::Dict{Int16, Dataset{2, T}}
+    attractors::Dict{Int16, Dataset{N, T}}
     visited::Q
 end
 
@@ -288,7 +288,7 @@ function store_attractor!(bsn_nfo::BasinInfo, u)
     if haskey(bsn_nfo.attractors , bsn_nfo.current_color ÷ 2)
         push!(bsn_nfo.attractors[bsn_nfo.current_color ÷ 2],  u) # store attractor
     else
-        bsn_nfo.attractors[bsn_nfo.current_color ÷ 2] = Dataset([SVector(u[1],u[2])])  # init dic
+        bsn_nfo.attractors[bsn_nfo.current_color ÷ 2] = Dataset([SVector(u...)])  # init dic
     end
 end
 
@@ -316,7 +316,7 @@ examples for a Poincaré map of a continuous system.
 function draw_basin!(xg, yg, integ, iter_f!::Function, reinit_f!::Function, get_u::Function, mc_att, mc_bas, mc_unmb)
     complete = false
     bsn_nfo = BasinInfo(ones(Int16, length(xg), length(yg)), xg, yg,
-                iter_f!, reinit_f!, get_u, 2,4,0,0,0,1,1,0,0,Dict{Int16,Dataset{2,eltype(get_u(integ))}}(), Vector{CartesianIndex}())
+                iter_f!, reinit_f!, get_u, 2,4,0,0,0,1,1,0,0,Dict{Int16,Dataset{length(integ.u),eltype(integ.u)}}(), Vector{CartesianIndex}())
     reset_bsn_nfo!(bsn_nfo)
     I = CartesianIndices(bsn_nfo.basin)
     j  = 1
@@ -366,7 +366,7 @@ function get_color_point!(bsn_nfo::BasinInfo, integ, u0, mc_att, mc_bas, mc_unmb
        n = get_box(new_u, bsn_nfo)
 
        if !isnothing(n) # apply procedure only for boxes in the defined space
-           done = procedure!(bsn_nfo, n, new_u, mc_att, mc_bas, mc_unmb)
+           done = procedure!(bsn_nfo, n, integ.u, mc_att, mc_bas, mc_unmb)
            inlimbo = 0
        else
            # We are outside the defined grid

--- a/src/basins/compute_ba.jl
+++ b/src/basins/compute_ba.jl
@@ -314,9 +314,10 @@ examples for a Poincaré map of a continuous system.
 * `reinit_f!` : function that sets the initial condition to test on a two dimensional projection of the phase space.
 """
 function draw_basin!(xg, yg, integ, iter_f!::Function, reinit_f!::Function, get_u::Function, mc_att, mc_bas, mc_unmb)
+    NDS = length(get_state(integ))
     complete = false
     bsn_nfo = BasinInfo(ones(Int16, length(xg), length(yg)), xg, yg,
-                iter_f!, reinit_f!, get_u, 2,4,0,0,0,1,1,0,0,Dict{Int16,Dataset{length(integ.u),eltype(integ.u)}}(), Vector{CartesianIndex}())
+                iter_f!, reinit_f!, get_u, 2,4,0,0,0,1,1,0,0,Dict{Int16,Dataset{NDS,eltype(get_state(integ))}}(), Vector{CartesianIndex}())
     reset_bsn_nfo!(bsn_nfo)
     I = CartesianIndices(bsn_nfo.basin)
     j  = 1
@@ -366,7 +367,7 @@ function get_color_point!(bsn_nfo::BasinInfo, integ, u0, mc_att, mc_bas, mc_unmb
        n = get_box(new_u, bsn_nfo)
 
        if !isnothing(n) # apply procedure only for boxes in the defined space
-           done = procedure!(bsn_nfo, n, integ.u, mc_att, mc_bas, mc_unmb)
+           done = procedure!(bsn_nfo, n, get_state(integ), mc_att, mc_bas, mc_unmb)
            inlimbo = 0
        else
            # We are outside the defined grid

--- a/src/orbitdiagrams/poincare.jl
+++ b/src/orbitdiagrams/poincare.jl
@@ -253,6 +253,9 @@ function DynamicalSystemsBase.reinit!(pmap::PoincareMap, u0)
 	reinit!(pmap.integ, u0)
 	return
 end
+function DynamicalSystemsBase.get_state(pmap::PoincareMap)
+	return pmap.integ.u
+end
 
 function Base.show(io::IO, pmap::PoincareMap)
     println(io, "Iterator of the Poincaré map")

--- a/test/basins/basins_tests.jl
+++ b/test/basins/basins_tests.jl
@@ -5,12 +5,10 @@ using Test
 @testset "Basins tests" begin
 
 @testset "Test basin stroboscopic map" begin
-    ω=1.; F = 0.2
-    ds =Systems.duffing([0.1, 0.25]; ω = ω, f = F, d = 0.15, β = -1)
+    ds = Systems.duffing([0.1, 0.25]; ω = 1., f = 0.2, d = 0.15, β = -1)
     integ_df  = integrator(ds; abstol=1e-8, save_everystep=false)
-    xg = range(-2.2,2.2,length=100)
-    yg = range(-2.2,2.2,length=100)
-    basin,attractors = basins_map2D(xg, yg, integ_df; T=2*pi/ω)
+    xg = yg = range(-2.2,2.2,length=100)
+    basin,attractors = basins_map2D(xg, yg, integ_df; T=2*pi/1.)
     # pcolormesh(xg, yg, basin')
 
     @test length(unique(basin)) == 2
@@ -20,10 +18,8 @@ using Test
 end
 
 @testset "Test basin poincare map" begin
-    b=0.1665
-    ds = Systems.thomas_cyclical(b = b)
-    xg=range(-6.,6.,length=100)
-    yg=range(-6.,6.,length=100)
+    ds = Systems.thomas_cyclical(b = 0.1665)
+    xg = yg = range(-6.,6.,length=100)
     pmap = poincaremap(ds, (3, 0.), Tmax=1e6; idxs = 1:2, rootkw = (xrtol = 1e-8, atol = 1e-8), reltol=1e-9)
     basin,attractors = basins_map2D(xg, yg, pmap)
     # pcolormesh(xg, yg, basin')
@@ -37,11 +33,9 @@ end
 @testset "Test basin discrete map" begin
     ds = Systems.henon(zeros(2); a = 1.4, b = 0.3)
     integ_df  = integrator(ds)
-    xg = range(-2.,2.,length=100)
-    yg = range(-2.,2.,length=100)
+    xg = yg = range(-2.,2.,length=100)
     basin,attractors = basins_map2D(xg, yg, integ_df)
     # pcolormesh(xg, yg, basin')
-
     @test count(basin .== 1) == 4270
     @test count(basin .== -1) == 5730
 end


### PR DESCRIPTION
Now the dictionary `attractor` has the full state of the dynamical system. 

I added a function get_state for Poincaré Maps for compatibility. Doesn't break anything.  