### PR TITLE
Better `lyapunovspectrum` performance for in-place systems

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ChaosTools"
 uuid = "608a59af-f2a3-5ad4-90b4-758bdf3122a7"
 repo = "https://github.com/JuliaDynamics/ChaosTools.jl.git"
-version = "1.32.0"
+version = "1.32.1"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
@@ -29,7 +29,7 @@ DSP = "0.6, 0.7"
 DelayEmbeddings = "1"
 Distances = "0.7, 0.8, 0.9, 0.10"
 Distributions = "0.21, 0.22, 0.23, 0.24, 0.25"
-DynamicalSystemsBase = "1.8.8"
+DynamicalSystemsBase = "1.8.11"
 Entropies = "0.12"
 ForwardDiff = "0.8, 0.9, 0.10"
 LombScargle = "0.4, 0.5, 1.0"

--- a/src/chaosdetection/lyapunovs.jl
+++ b/src/chaosdetection/lyapunovs.jl
@@ -83,7 +83,6 @@ function lyapunovspectrum(ds::DS{IIP, S, D}, N, Q0::AbstractMatrix;
 end
 
 function lyapunovspectrum(integ, N, dt::Real, Ttr::Real = 0.0)
-    T = stateeltype(integ)
     B = copy(get_deviations(integ)) # for use in buffer
     if Ttr > 0
         t0 = integ.t
@@ -93,9 +92,9 @@ function lyapunovspectrum(integ, N, dt::Real, Ttr::Real = 0.0)
             set_deviations!(integ, Q)
         end
     end
-    
+
     k = size(get_deviations(integ))[2]
-    λ::Vector{T} = zeros(T, k)
+    λ = zeros(stateeltype(integ), k)
     t0 = integ.t
     for _ in 2:N
         step!(integ, dt)


### PR DESCRIPTION
Let `hh = Systems.henonheiles()`.

Before:
```
julia> @btime lyapunovspectrum($hh, 10000, 3)
ERROR: DimensionMismatch("array could not be broadcast to match destination")

julia> @btime lyapunovspectrum($hh, 10000, 4)
  192.722 ms (560039 allocations: 65.46 MiB)
4-element Vector{Float64}:
  0.061219198559359665
  0.00042709628745806
 -0.00042717471586642235
 -0.06121923821165012
```
After:
```
julia> @btime lyapunovspectrum($hh, 10000, 3)
  95.696 ms (40092 allocations: 6.11 MiB)
3-element Vector{Float64}:
  0.06118782704720026
  0.0005764356389028238
 -0.0005499087441797644

julia> @btime lyapunovspectrum($hh, 10000, 4)
  105.436 ms (40092 allocations: 7.94 MiB)
4-element Vector{Float64}:
  0.061206577665269525
  0.00049284152018765
 -0.0007613639615602138
 -0.060938173304595604
```