### PR TITLE
Basins zoom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 1.34
+* New option in `basins_of_attraction` that allows refining already found basins.
+
 # 1.33
 * `lyapunovspectrum` now has a progress meter option.
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ChaosTools"
 uuid = "608a59af-f2a3-5ad4-90b4-758bdf3122a7"
 repo = "https://github.com/JuliaDynamics/ChaosTools.jl.git"
-version = "1.33.0"
+version = "1.34.0"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/basins/basins_highlevel.jl
+++ b/src/basins/basins_highlevel.jl
@@ -15,7 +15,7 @@ The dynamical system can be:
   for this particular application).
 
 `grid` is a tuple of ranges defining the grid of initial conditions, for example
-`grid=(xg,yg)` where `xg` and `yg` are one dimensional ranges. The grid is not necessarilly
+`grid = (xg, yg)` where `xg = yg = range(-5, 5; length = 100)`. The grid is not necessarilly
 of the same dimension as the state space, attractors can be found in lower dimensional
 projections.
 
@@ -38,7 +38,7 @@ See also [`match_attractors!`](@ref), [`basin_fractions`](@ref), [`tipping_proba
 * `idxs = 1:length(grid)`: This vector selects the variables of the system that will define the
   subspace the dynamics will be projected into.
 * `complete_state = zeros(D-Dg)`: This argument allows setting the _remaining_ variables
-  of the dynamical system state on each initial condition `u`, beeing `Dg` the dimension
+  of the dynamical system state on each initial condition `u`, with `Dg` the dimension
   of the grid. It can be either a vector of length `D-Dg`, or a function `f(y)` that
   returns a vector of length `D-Dg` given the _projected_ initial condition on the grid `y`.
 * `diffeq...`: Keyword arguments propagated to [`integrator`](@ref).
@@ -94,13 +94,14 @@ attribute the value `-1` to all grid points. For these cases, an extra search cl
 be provided by setting the keywords `attractors, ε`. The `attractors` is a dictionary
 mapping attractor IDs to `Dataset`s (i.e., the same as the return value of
 `basins_of_attraction`). The algorithm checks at each step whether the system state is
-`ε`-close to any of the given attractors, and if so it attributes the stating grid point
-to the basin of the close attractor. By default `ε = 1e-3`.
+`ε`-close (Euclidean norm) to any of the given attractors, and if so it attributes the stating grid point
+to the basin of the close attractor. By default `ε` is equal to the mean grid spacing.
 
 A word of advice while using this method: in order to work properly, `ε` should be
-about the size of a grid cell that has been used to compute the attractors. It is
-recomended to keep the same step size since it may have an influence in some cases.
-Also this algorithm is usually slower than the method with the attractors on the grid.
+about the size of a grid cell that has been used to compute the given `attractors`. It is
+recomended to keep the same step size (i.e., use the same integrator) since it may have an
+influence in some cases. This algorithm is usually slower than the method with the 
+attractors on the grid.
 """
 function basins_of_attraction(grid::Tuple, ds;
         Δt=1, T=0, idxs = 1:length(grid),

--- a/src/basins/basins_highlevel.jl
+++ b/src/basins/basins_highlevel.jl
@@ -48,11 +48,13 @@ See also [`match_attractors!`](@ref), [`basin_fractions`](@ref), [`tipping_proba
   This number can be increased for higher accuracy.
 * `mx_chk_fnd_att = 60` : Maximum check of unnumbered cell before considering we have an attractor.
   This number can be increased for higher accuracy.
-* `mx_chk_lost = 100` : Maximum check of iterations outside the defined grid before we consider the orbit
-  lost outside. This number can be increased for higher accuracy.
+* `mx_chk_lost` : Maximum check of iterations outside the defined grid before we consider the orbit
+  lost outside. This number can be increased for higher accuracy. It defaults to `20` if no
+  attractors are given (see discussion on refining the basins), and to `1000` if attractors are given.
 * `horizon_limit = 1e6` : If the norm of the integrator state reaches this limit we consider that the
   orbit diverges.
 * `show_progress = true` : By default a progress bar is shown using ProgressMeter.jl.
+* `attractors, ε`: See discussion on refining the basin below.
 
 ## Description
 `basins` has the following organization:
@@ -83,6 +85,19 @@ Notice that in the case we have to project the dynamics on a lower dimensional s
 there are edge cases where the system may have two attractors
 that are close on the projected space but are far apart in another dimension. They could
 be collapsed or confused into the same attractor. This is a drawback of this method.
+
+## Refining basins of attraction
+Sometimes one would like to be able to refine the found basins of attraction by recomputing
+`basins_of_attraction` on a smaller, and more fine-grained, `grid`. If however this 
+new `grid` does not contain the attractors, `basins_of_attraction` would (by default)
+attribute the value `-1` to all grid points. For these cases, an extra search clause can
+be provided by setting the keywords `attractors, ε`. The `attractors` is a dictionary 
+mapping attractor IDs to `Dataset`s (i.e., the same as the return value of 
+`basins_of_attraction`). The algorithm checks at each step whether the system state is 
+`ε`-close to any of the given attractors, and if so it attributes the stating grid point
+to the basin of the close attractor. By default `ε = 1e-3`.
+
+*Some comments here on why this method could be a bit wonky or fail*.
 """
 function basins_of_attraction(grid::Tuple, ds;
         Δt=1, T=0, idxs = 1:length(grid),

--- a/src/basins/basins_highlevel.jl
+++ b/src/basins/basins_highlevel.jl
@@ -88,16 +88,19 @@ be collapsed or confused into the same attractor. This is a drawback of this met
 
 ## Refining basins of attraction
 Sometimes one would like to be able to refine the found basins of attraction by recomputing
-`basins_of_attraction` on a smaller, and more fine-grained, `grid`. If however this 
+`basins_of_attraction` on a smaller, and more fine-grained, `grid`. If however this
 new `grid` does not contain the attractors, `basins_of_attraction` would (by default)
 attribute the value `-1` to all grid points. For these cases, an extra search clause can
-be provided by setting the keywords `attractors, ε`. The `attractors` is a dictionary 
-mapping attractor IDs to `Dataset`s (i.e., the same as the return value of 
-`basins_of_attraction`). The algorithm checks at each step whether the system state is 
+be provided by setting the keywords `attractors, ε`. The `attractors` is a dictionary
+mapping attractor IDs to `Dataset`s (i.e., the same as the return value of
+`basins_of_attraction`). The algorithm checks at each step whether the system state is
 `ε`-close to any of the given attractors, and if so it attributes the stating grid point
 to the basin of the close attractor. By default `ε = 1e-3`.
 
-*Some comments here on why this method could be a bit wonky or fail*.
+A word of advice while using this method: in order to work properly, `ε` should be
+about the size of a grid cell that has been used to compute the attractors. It is
+recomended to keep the same step size since it may have an influence in some cases.
+Also this algorithm is usually slower than the method with the attractors on the grid.
 """
 function basins_of_attraction(grid::Tuple, ds;
         Δt=1, T=0, idxs = 1:length(grid),

--- a/src/basins/basins_highlevel.jl
+++ b/src/basins/basins_highlevel.jl
@@ -50,11 +50,11 @@ See also [`match_attractors!`](@ref), [`basin_fractions`](@ref), [`tipping_proba
   This number can be increased for higher accuracy.
 * `mx_chk_lost` : Maximum check of iterations outside the defined grid before we consider the orbit
   lost outside. This number can be increased for higher accuracy. It defaults to `20` if no
-  attractors are given (see discussion on refining the basins), and to `1000` if attractors are given.
+  attractors are given (see discussion on refining basins), and to `1000` if attractors are given.
 * `horizon_limit = 1e6` : If the norm of the integrator state reaches this limit we consider that the
   orbit diverges.
 * `show_progress = true` : By default a progress bar is shown using ProgressMeter.jl.
-* `attractors, ε`: See discussion on refining the basin below.
+* `attractors, ε`: See discussion on refining basins below.
 
 ## Description
 `basins` has the following organization:

--- a/src/basins/basins_lowlevel.jl
+++ b/src/basins/basins_lowlevel.jl
@@ -137,7 +137,7 @@ function _identify_basin_of_cell!(
         bsn_nfo::BasinInfo, n::CartesianIndex, u_full_state;
         mx_chk_att = 2, mx_chk_hit_bas = 10, mx_chk_fnd_att = 100,
         horizon_limit = 1e6, ε = 1e-3,
-        mx_chk_lost = isnothing(bsn_info.search_trees) ? 20 : 1000,
+        mx_chk_lost = isnothing(bsn_nfo.search_trees) ? 20 : 1000,
     )
 
     #if n[1]==-1 means we are outside the grid

--- a/src/basins/basins_lowlevel.jl
+++ b/src/basins/basins_lowlevel.jl
@@ -33,12 +33,10 @@ function draw_basin!(
     B = length(grid)
     D = length(get_state(integ)) # dimension of the full state space
     complete = false
-    trees = nothing
-    if !isnothing(attractors)
-        trees = [searchstructure(KDTree, att, Euclidean()) for att in values(attractors)]
-        # reorder to get correct attractors
-        idxs = collect(keys(attractors))
-        trees = trees[idxs]
+    trees = if isnothing(attractors)
+        nothing
+    else
+        Dict(k => searchstructure(KDTree, att, Euclidean()) for (k, att) in attractors)
     end
     grid_steps = step.(grid)
     grid_maxima = maximum.(grid)
@@ -146,7 +144,7 @@ function _identify_basin_of_cell!(
 
     # search attractors directly
     if !isnothing(bsn_nfo.search_trees)
-        for (k,t) in enumerate(bsn_nfo.search_trees)
+        for (k, t) in bsn_nfo.search_trees # this is a `Dict`
             idxs = isearch(t, u_full_state, WithinRange(ε))
             if !isempty(idxs)
                 nxt_clr = 2*k + 1

--- a/src/basins/basins_lowlevel.jl
+++ b/src/basins/basins_lowlevel.jl
@@ -135,8 +135,9 @@ and the trajectories staying outside the grid are coded with -1.
 """
 function _identify_basin_of_cell!(
         bsn_nfo::BasinInfo, n::CartesianIndex, u_full_state;
-        mx_chk_att = 2, mx_chk_hit_bas = 10, mx_chk_fnd_att = 100, mx_chk_lost = 100,
-        horizon_limit = 1e6, ε = 1e-5
+        mx_chk_att = 2, mx_chk_hit_bas = 10, mx_chk_fnd_att = 100,
+        horizon_limit = 1e6, ε = 1e-3,
+        mx_chk_lost = isnothing(bsn_info.search_trees) ? 20 : 1000,
     )
 
     #if n[1]==-1 means we are outside the grid

--- a/src/basins/basins_lowlevel.jl
+++ b/src/basins/basins_lowlevel.jl
@@ -1,4 +1,5 @@
 import ProgressMeter
+using Statistics: mean
 
 mutable struct BasinInfo{B, IF, RF, UF, D, T, Q, K}
     basin::Array{Int16, B}
@@ -72,7 +73,7 @@ function draw_basin!(
         y0 = generate_ic_on_grid(grid, ind)
         bsn_nfo.basin[ind] = get_color_point!(bsn_nfo, integ, y0; kwargs...)
     end
-    # remove attractors and rescale from 1 to max nmb of attractors
+    # remove attractors and rescale from 1 to max number of attractors
     ind = iseven.(bsn_nfo.basin)
     bsn_nfo.basin[ind] .+= 1
     bsn_nfo.basin .= (bsn_nfo.basin .- 1) .÷ 2
@@ -117,7 +118,7 @@ function get_color_point!(bsn_nfo::BasinInfo, integ, y0; kwargs...)
 end
 
 """
-Main procedure described by Nusse & Yorke for the grid cell `n`. The algorithm can be
+Main procedure motivated by Nusse & Yorke for the grid cell `n`. The algorithm can be
 though as a finite state machine with five states: :att_hit, :att_search, :att_found,
 :bas_hit, :lost. The transition between states depends on the current number in the
 cell being visited by the trajectory of the dynamical systems. When the automata switches

--- a/src/basins/basins_utilities.jl
+++ b/src/basins/basins_utilities.jl
@@ -201,7 +201,7 @@ function basins_fractal_test(basins; ε = 20, Ntotal = 1000)
     end
 
     Ŝbb = mean(N_stat[100:end])
-    σ_sbb = std(N_stat[100:end])
+    σ_sbb = std(N_stat[100:end])/sqrt(length(N_stat[100:end]))
     # Table of boundary basin entropy of a smooth boundary for dimension 1 to 5:
     Sbb_tab = [0.499999, 0.4395093, 0.39609176, 0.36319428, 0.33722572]
     if length(dims) ≤ 5

--- a/test/basins/basins_tests.jl
+++ b/test/basins/basins_tests.jl
@@ -55,8 +55,8 @@ end
     basins, att = basins_of_attraction((xg,yg), ds;
     idxs = 1:2, complete_state, show_progress = false,
     attractors = attractors, mx_chk_lost = 1000, ε = 1e-3)
-    @test count(basin .== 1) == 407
-    @test count(basin .== 2) == 737
+    @test count(basins .== 1) == 407
+    @test count(basins .== 2) == 737
 end
 
 @testset "3D basins" begin

--- a/test/basins/basins_tests.jl
+++ b/test/basins/basins_tests.jl
@@ -55,8 +55,8 @@ end
     basins, att = basins_of_attraction((xg,yg), ds;
     idxs = 1:2, complete_state, show_progress = false,
     attractors = attractors, mx_chk_lost = 1000, ε = 1e-3)
-    @test count(basins .== 1) == 407
-    @test count(basins .== 2) == 737
+    @test count(basins .== 3) == 407
+    @test count(basins .== 1) == 737
 end
 
 @testset "3D basins" begin

--- a/test/basins/basins_tests.jl
+++ b/test/basins/basins_tests.jl
@@ -39,16 +39,24 @@ end
     @test  2640 ≤ count(basin .== 3) ≤ 2691
 end
 
-@testset "basin_general" begin
+@testset "basins_of_attraction" begin
     ds = Systems.magnetic_pendulum(γ=1, d=0.2, α=0.2, ω=0.8, N=3)
-    xg=range(-2,2,length=100)
-    yg=range(-2,2,length=100)
+    xg = range(-2,2,length=100)
+    yg = range(-2,2,length=100)
     complete_state(y) = SVector(0,0)
     basin, attractors = basins_of_attraction((xg,yg), ds;
     idxs=1:2, complete_state, show_progress = false)
     # pcolormesh(xg,yg, basin')
     @test count(basin .== 1) == 3332
     @test count(basin .== 2) == 3332
+
+    # Now test the zoom capability
+    xg = yg = range(-2,-1.9,length=50)
+    basins, att = basins_of_attraction((xg,yg), ds;
+    idxs = 1:2, complete_state, show_progress = false,
+    attractors = attractors, mx_chk_lost = 1000, ε = 1e-3)
+    @test count(basin .== 1) == 407
+    @test count(basin .== 2) == 737
 end
 
 @testset "3D basins" begin

--- a/test/basins/basins_tests.jl
+++ b/test/basins/basins_tests.jl
@@ -43,7 +43,7 @@ end
     ds = Systems.magnetic_pendulum(γ=1, d=0.2, α=0.2, ω=0.8, N=3)
     xg = range(-2,2,length=100)
     yg = range(-2,2,length=100)
-    complete_state(y) = SVector(0,0)
+    complete_state(y) = SVector(0.0, 0.0)
     basin, attractors = basins_of_attraction((xg,yg), ds;
     idxs=1:2, complete_state, show_progress = false)
     # pcolormesh(xg,yg, basin')
@@ -55,8 +55,8 @@ end
     basins, att = basins_of_attraction((xg,yg), ds;
     idxs = 1:2, complete_state, show_progress = false,
     attractors = attractors, mx_chk_lost = 1000, ε = 1e-3)
-    @test count(basins .== 3) == 407
-    @test count(basins .== 1) == 737
+    @test count(basins .== 2) == 407
+    @test count(basins .== 3) == 737
 end
 
 @testset "3D basins" begin


### PR DESCRIPTION
I introduced the "zoom" capability. When the attractors are known we can pass them to `basins_of_attraction`. 

It works but the user should be advised that it will require some tweaking of the parameter since you don't have a grid to work on. For example, the radius of search is critical. Also you need to bump `mx_chk_lost` to 1000 at least since the trajectory will spend most of the time outside the grid. 

I did not check if there is an impact on the performances. I think it is negligible. 