### PR TITLE
Fixed mistake in return of estimate_period with YIN.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ChaosTools"
 uuid = "608a59af-f2a3-5ad4-90b4-758bdf3122a7"
 repo = "https://github.com/JuliaDynamics/ChaosTools.jl.git"
-version = "2.6"
+version = "2.6.1"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/period_return/period.jl
+++ b/src/period_return/period.jl
@@ -88,7 +88,7 @@ function estimate_period(v, method, t = 0:length(v)-1; kwargs...)
                 elseif method == :yin 
                     sr = get(kwargs, :sr, 22050)
                     f0s, _ = yin(v, sr; kwargs...)
-                    sr/mean(f0s)
+                    1/mean(f0s)
                 end
             else
                 if method == :lombscargle || method == :ls


### PR DESCRIPTION
 Period T0 should be 1/f0, not sr/f0. Now the estimated period for the [example](https://juliadynamics.github.io/DynamicalSystems.jl/dev/chaos/periodicity/#ChaosTools.estimate_period) using a FitzHugh-Nagumo oscillator is the correct value of around 91.07.