### PR TITLE
Fix nearest neighbors search of attractors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ChaosTools"
 uuid = "608a59af-f2a3-5ad4-90b4-758bdf3122a7"
 repo = "https://github.com/JuliaDynamics/ChaosTools.jl.git"
-version = "2.6.4"
+version = "2.6.5"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/src/basins/basins_lowlevel.jl
+++ b/src/basins/basins_lowlevel.jl
@@ -133,7 +133,7 @@ and the trajectories staying outside the grid are coded with -1.
 function _identify_basin_of_cell!(
         bsn_nfo::BasinInfo, n::CartesianIndex, u_full_state;
         mx_chk_att = 2, mx_chk_hit_bas = 10, mx_chk_fnd_att = 100, mx_chk_loc_att = 100,
-        horizon_limit = 1e6, ε = 1e-5,
+        horizon_limit = 1e6, ε = 1e-3,
         mx_chk_lost = isnothing(bsn_nfo.search_trees) ? 20 : 1000,
     )
 
@@ -146,7 +146,7 @@ function _identify_basin_of_cell!(
             Neighborhood.NearestNeighbors.knn_point!(t, u_full_state, false, bsn_nfo.dist, bsn_nfo.neighborindex, Neighborhood.alwaysfalse)
             if bsn_nfo.dist[1] < ε
                 nxt_clr = 2*k + 1
-                break
+                return nxt_clr
             end
         end
     end

--- a/src/basins/basins_lowlevel.jl
+++ b/src/basins/basins_lowlevel.jl
@@ -18,6 +18,8 @@ mutable struct BasinInfo{B, IF, RF, UF, D, T, Q, K}
     attractors::Dict{Int16, Dataset{D, T}}
     visited::Q
     search_trees::K
+    dist::Vector{Float64}
+    neighborindex::Vector{Int64};
 end
 
 
@@ -54,7 +56,9 @@ function draw_basin!(
         2,4,0,1,1,
         Dict{Int16,Dataset{D,eltype(get_state(integ))}}(),
         Vector{CartesianIndex{B}}(),
-        trees
+        trees,
+        [Inf],
+        [0]
     )
     reset_basin_counters!(bsn_nfo)
     I = CartesianIndices(bsn_nfo.basin)
@@ -138,13 +142,18 @@ function _identify_basin_of_cell!(
 
     # search attractors directly
     if !isnothing(bsn_nfo.search_trees)
-        dist = [Inf]; neighborindex = [0];
         for (k, t) in bsn_nfo.search_trees # this is a `Dict`
-            Neighborhood.NearestNeighbors.knn_point!(t, u_full_state, false, dist, neighborindex, Neighborhood.alwaysfalse)
-            if dist[1] < ε
+            Neighborhood.NearestNeighbors.knn_point!(t, u_full_state, false, bsn_nfo.dist, bsn_nfo.neighborindex, Neighborhood.alwaysfalse)
+            #@show bsn_nfo.dist
+            if bsn_nfo.dist[1] < ε
                 nxt_clr = 2*k + 1
                 break
             end
+            # idx = isearch(t, u_full_state, NeighborNumber(1))
+            # if norm(t.data[idx][1] - u_full_state) < ε
+            #     nxt_clr = 2*k + 1
+            #     break
+            # end
         end
     end
 

--- a/src/basins/basins_lowlevel.jl
+++ b/src/basins/basins_lowlevel.jl
@@ -139,8 +139,9 @@ function _identify_basin_of_cell!(
     # search attractors directly
     if !isnothing(bsn_nfo.search_trees)
         for (k, t) in bsn_nfo.search_trees # this is a `Dict`
-            idxs = isearch(t, u_full_state, WithinRange(ε))
-            if !isempty(idxs)
+            dist = [Inf]; neighborindex = [0];
+            Neighborhood.NearestNeighbors.knn_point!(t, u_full_state, false, dist, neighborindex, Neighborhood.alwaysfalse)
+            if dist < ε
                 nxt_clr = 2*k + 1
                 break
             end

--- a/src/basins/basins_lowlevel.jl
+++ b/src/basins/basins_lowlevel.jl
@@ -138,10 +138,10 @@ function _identify_basin_of_cell!(
 
     # search attractors directly
     if !isnothing(bsn_nfo.search_trees)
+        dist = [Inf]; neighborindex = [0];
         for (k, t) in bsn_nfo.search_trees # this is a `Dict`
-            dist = [Inf]; neighborindex = [0];
             Neighborhood.NearestNeighbors.knn_point!(t, u_full_state, false, dist, neighborindex, Neighborhood.alwaysfalse)
-            if dist < ε
+            if dist[1] < ε
                 nxt_clr = 2*k + 1
                 break
             end

--- a/src/basins/basins_lowlevel.jl
+++ b/src/basins/basins_lowlevel.jl
@@ -133,7 +133,7 @@ and the trajectories staying outside the grid are coded with -1.
 function _identify_basin_of_cell!(
         bsn_nfo::BasinInfo, n::CartesianIndex, u_full_state;
         mx_chk_att = 2, mx_chk_hit_bas = 10, mx_chk_fnd_att = 100, mx_chk_loc_att = 100,
-        horizon_limit = 1e6, ε = 1e-3,
+        horizon_limit = 1e6, ε = 1e-5,
         mx_chk_lost = isnothing(bsn_nfo.search_trees) ? 20 : 1000,
     )
 
@@ -144,16 +144,10 @@ function _identify_basin_of_cell!(
     if !isnothing(bsn_nfo.search_trees)
         for (k, t) in bsn_nfo.search_trees # this is a `Dict`
             Neighborhood.NearestNeighbors.knn_point!(t, u_full_state, false, bsn_nfo.dist, bsn_nfo.neighborindex, Neighborhood.alwaysfalse)
-            #@show bsn_nfo.dist
             if bsn_nfo.dist[1] < ε
                 nxt_clr = 2*k + 1
                 break
             end
-            # idx = isearch(t, u_full_state, NeighborNumber(1))
-            # if norm(t.data[idx][1] - u_full_state) < ε
-            #     nxt_clr = 2*k + 1
-            #     break
-            # end
         end
     end
 


### PR DESCRIPTION
Fix to reduce the number of allocations in the second mode of operation in `basins_of_attraction`. 

Two new variables have been added to BasinsInfo. 

New default value ε = 1e-5

Closes #238 

