### PR TITLE
Remove boundcheck for SparseArray.jl

### DIFF
--- a/src/basins/mapping/attractor_mapping_recurrences.jl
+++ b/src/basins/mapping/attractor_mapping_recurrences.jl
@@ -40,7 +40,7 @@ dimensional subspace.
 * `horizon_limit = 1e6`: If the norm of the integrator state reaches this
   limit we consider that the orbit diverges.
 * `safety_counter_max = Int(1e6)`: A safety counter that is always increasing for
-  each initial condition. Once exceeded, the algorithm errors.
+  each initial condition. Once exceeded, the algorithm assigns `-1` and throws a warning.
   This clause exists to stop the algorithm never haulting for innappropriately defined grids,
   where a found attractor may intersect in the same cell with a new attractor the orbit
   traces (which leads to infinite resetting of all counters). As this check comes with a
@@ -320,7 +320,8 @@ function get_label_ic!(bsn_nfo::BasinsInfo, integ, u0; safety_counter_max = Int(
         # on the previously found one...
         bsn_nfo.unsafe || (bsn_nfo.safety_counter += 1)
         if bsn_nfo.unsafe || (bsn_nfo.safety_counter ≥ safety_counter_max)
-            @warn  """`AttractorsViaRecurrences` algorithm exceeded safety count without haulting.
+            @warn  """
+            `AttractorsViaRecurrences` algorithm exceeded safety count without haulting.
             It may be that the grid is not fine enough and attractors intersect in the
             same cell, or `safety_counter_max` is not high enough for a very fine grid.
             Iteration will terminate now and exit with error.

--- a/src/basins/mapping/attractor_mapping_recurrences.jl
+++ b/src/basins/mapping/attractor_mapping_recurrences.jl
@@ -320,15 +320,14 @@ function get_label_ic!(bsn_nfo::BasinsInfo, integ, u0; safety_counter_max = Int(
         # on the previously found one...
         bsn_nfo.unsafe || (bsn_nfo.safety_counter += 1)
         if bsn_nfo.unsafe || (bsn_nfo.safety_counter ≥ safety_counter_max)
-            error(
-            """`AttractorsViaRecurrences` algorithm exceeded safety count without haulting.
+            @warn  """`AttractorsViaRecurrences` algorithm exceeded safety count without haulting.
             It may be that the grid is not fine enough and attractors intersect in the
             same cell, or `safety_counter_max` is not high enough for a very fine grid.
             Iteration will terminate now and exit with error.
             Here are some info on current status:\n
             state: $(get_state(integ)),\n
             parameters: $(get_parameters(integ)).
-            """)
+            """
             return -1
         end
 

--- a/src/basins/mapping/sparse_arrays.jl
+++ b/src/basins/mapping/sparse_arrays.jl
@@ -45,14 +45,12 @@ Base.size(a::SparseArray) = a.dims
 # Indexing
 #########################################################################################
 @inline function Base.getindex(a::SparseArray{T,N}, I::CartesianIndex{N}) where {T,N}
-    @boundscheck checkbounds(a, I)
     return get(a.data, I, zero(T))
 end
 Base.@propagate_inbounds Base.getindex(a::SparseArray{T,N}, I::Vararg{Int,N}) where {T,N} =
                                         getindex(a, CartesianIndex(I))
 
 @inline function Base.setindex!(a::SparseArray{T,N}, v, I::CartesianIndex{N}) where {T,N}
-    @boundscheck checkbounds(a, I)
     if v != zero(v)
         a.data[I] = v
     else


### PR DESCRIPTION
After a profiling of the code for the sparse version of the `AttractorsViaRecurrences` I found that 50% of the computing time was dedicated to `@boundcheck` in the `SparseArray.jl` file (no joking!). I removed this boundcheck assuming that the user will **never** use the version included in `ChaosTools.jl`. 

However this is a strong performance vs safety case. 

The other change is minor: change from `error` to `@warn` when the safety counter hits the ceiling. The initial condition is labeled -1 and the program goes on. It is frustrating when the continuation program throws an error after two hours of computing. 
