### PR TITLE
Correct assignment of Q matrix for lyapunovspectrum with k < d

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ChaosTools"
 uuid = "608a59af-f2a3-5ad4-90b4-758bdf3122a7"
 repo = "https://github.com/JuliaDynamics/ChaosTools.jl.git"
-version = "3.0.1"
+version = "3.0.2"
 
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"

--- a/test/chaosdetection/lyapunovs.jl
+++ b/test/chaosdetection/lyapunovs.jl
@@ -35,11 +35,14 @@ p0_cont = [0.1, -0.4]
             Jf = IIP ? trivial_jac_iip : trivial_jac
             tands = TangentDynamicalSystem(ds; J = Jf)
             spec = lyapunovspectrum(tands, 100; Δt = 1)
+            spec1 = lyapunovspectrum(TangentDynamicalSystem(ds; k = 1, J = Jf), 100; Δt = 1)
         else
             spec = lyapunovspectrum(ds, 100; Δt = 1)
+            spec1 = lyapunovspectrum(ds, 100, 1; Δt = 1)
         end
 
         @test isapprox(spec[1], lyapunovs[1]; atol = 0, rtol = 1e-3)
+        @test isapprox(spec1[1], lyapunovs[1]; atol = 0, rtol = 1e-3)
         @test isapprox(spec[2], lyapunovs[2]; atol = 0, rtol = 1e-3)
     end
 


### PR DESCRIPTION
Wow. All these years. 5 years? the code for Lyapunov exponents was "wrong". Haha. It worked, but it was not coded properly. So I was just lucky that it worked. Now in the v3 re-write, the same code doesn't work.

This PR puts in a proper code that correctly respects the API and maps a higher size Q matrix to the deviations matrix.

Closes #302. 