### PR TITLE
Improve UPO storage in `periodicorbits.jl`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "3.1.2"
 [deps]
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Distances = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 DynamicalSystemsBase = "6e36e845-645a-534a-86f2-f5d4aa5a06b4"

--- a/src/ChaosTools.jl
+++ b/src/ChaosTools.jl
@@ -18,6 +18,7 @@ include("dimreduction/dyca.jl")
 include("stability/fixedpoints.jl")
 include("periodicity/period.jl")
 include("periodicity/yin.jl")
+include("periodicity/custombintree.jl")
 include("periodicity/periodicorbits.jl")
 
 include("rareevents/mean_return_times/mrt_api.jl")

--- a/src/periodicity/custombintree.jl
+++ b/src/periodicity/custombintree.jl
@@ -1,0 +1,35 @@
+using DataStructures: RBTree
+import Base: <, ==
+
+struct DummyStructure{T}
+    value::T
+    eps::Float64
+end
+
+function <(a::DummyStructure, b::DummyStructure)
+    abs_diff = norm(a.value - b.value)
+    return abs_diff > a.eps && a.value < b.value
+end
+
+function ==(a::DummyStructure, b::DummyStructure)
+    return norm(a.value - b.value) <= a.eps
+end
+
+function tovector(tree::RBTree{DummyStructure{T}}) where T
+    len = length(tree)
+    type = typeof(tree).parameters[1].parameters[1]
+    vect = Vector{type}(undef, len)
+    index = 1
+    _tovector!(tree.root, vect, index)
+    return vect
+end
+
+function _tovector!(node, vect::Vector{T}, index::Int64) where T
+    if !isnothing(node.data)
+        index = _tovector!(node.leftChild, vect, index)
+        vect[index] = node.data.value
+        index += 1
+        index = _tovector!(node.rightChild, vect, index)
+    end
+    return index
+end

--- a/test/periodicity/periodicorbits.jl
+++ b/test/periodicity/periodicorbits.jl
@@ -71,7 +71,7 @@ indss = [[1,2]] # <- must be container of vectors!!!
 λs = 0.005 # <- only this allowed to not be vector (could also be vector)
 
 @testset "order = $o" for o in [2, 3]
-    FP = periodicorbits(ds, o, ics, λs, indss, singss; roundtol = 4)
+    FP = periodicorbits(ds, o, ics, λs, indss, singss; spacetol = 1e-7)
     for fp in FP
         @test round(fp[1], digits = 4) ∈ ox[o]
         @test round(fp[2], digits = 4) ∈ oy[o]


### PR DESCRIPTION
I noticed that while using periodicorbits algorithm with parameter roundtol that is high (eg. 8 ), it detects many duplicate UPOs.
MVE:
```
using ChaosTools
using PredefinedDynamicalSystems: henon
begin
    ds = henon()
    xs = LinRange(-3.0, 3.0, 60)
    ys = LinRange(-10.0, 10.0, 60)
    seeds = [SVector{2}(x,y) for x in xs for y in ys]
    o = 5
    indss, signss = lambdaperms(dimension(ds))
    λ = 0.005
    results1 = sort!(periodicorbits(ds, o, seeds, λ, indss, signss; roundtol = 8))
end
```
Output:
```
10-element Vector{SVector{2, Float64}}:
 [-1.13135448, -0.33940634]
 [-1.13135448, -0.33940633]
 [-1.13135447, -0.33940636]
 [-1.13135447, -0.33940635]
 [0.63135447, 0.18940633]
 [0.63135447, 0.18940634]
 [0.63135448, 0.18940634]
 [0.63135448, 0.18940635]
 [0.63135449, 0.18940636]
 [0.63135449, 0.18940636]
 ```
My proposed change solves this:
```
using ChaosTools
using PredefinedDynamicalSystems: henon
begin
    ds = henon()
    xs = LinRange(-3.0, 3.0, 60)
    ys = LinRange(-10.0, 10.0, 60)
    seeds = [SVector{2}(x,y) for x in xs for y in ys]
    o = 5
    indss, signss = lambdaperms(dimension(ds))
    λ = 0.005
    results2 = sort!(periodicorbits(ds, o, seeds, λ, indss, signss; spacetol = 1e-7))
end
```
Output:
```
julia> results2
2-element Vector{SVector{2, Float64}}:
 [-1.1313544826122608, -0.33940632522716674]
 [0.6313544679502884, 0.18940632554538597]
 ```

I have implemented `FP` as a binary tree. This way,  new fixed points are inserted into `FP` only if they are `spacetol` away from the remaining fixed points in `FP`. Thus duplicates are avoided for a good choice of `spacetol`.

Additionally, binary tree removes the need for linear search through `FP` even though this doesn't seem to be a bottleneck.

Let me know if there is something to fix. This is my first PR :). 