### PR TITLE
Add successfull_step test to lyapunov calculation and warning in rescaling distance

### DIFF
--- a/test/chaosdetection/lyapunovs.jl
+++ b/test/chaosdetection/lyapunovs.jl
@@ -1,4 +1,4 @@
-using ChaosTools, Test
+using ChaosTools, Test, DynamicalSystemsBase
 using DelayEmbeddings: embed
 import Statistics
 
@@ -64,7 +64,7 @@ end
         end
 
         ds = CoupledODEs(lorenz_rule, fill(10.0, 3), [10, 20, 8/3])
-        @test lyapunov(ds, 1000, Ttr = 100) ≈ 0 atol = 1e-3
+        @test lyapunov(ds, 2000, Ttr = 100) ≈ 0 atol = 1e-3
     end
 end
 
@@ -106,4 +106,11 @@ end
     @test all(λlocal .< 1.0)
     mean_local = Statistics.mean(λlocal)
     @test λ-0.1 ≤ mean_local ≤ λ+0.1
+end
+
+@testset "testSuccessfulStep" begin
+    u0 = [NaN, 0]
+    p0 = [0.1, -0.4]
+    ds = CoupledODEs(trivial_rule, u0, p0) 
+    @test isnan(lyapunov(ds, 10; Ttr = 0, Δt = 0.5))
 end


### PR DESCRIPTION
This is related to the discussion in [262](https://github.com/JuliaDynamics/ChaosTools.jl/pull/262) and [184](https://github.com/JuliaDynamics/DynamicalSystems.jl/issues/184) as `successful_step` was not implemented in `lyapunov` function of DynamicalSystems.jl v3.

I'm also proposing that rescaling errors should give warnings instead of errors, as this might break execution of longer codes. The test is nothing fancy, but it does the job for testing `NaN`'s.

In my local files this addition makes the `@testset "analytic IDT=$(IDT), IIP=$(IIP)" ` to fail with an error 

` MethodError: no method matching isfinite(::SVector{2, Float64}) 
 The function `isfinite` exists, but no method is defined for this combination of argument types.`

in `dynamicalsystem_inferface.jl` file, I suspect this is some problem in my local instalations, but please double check.