### PR TITLE
feat: Add Covariant Lyapunov Vectors (CLV) via Ginelli algorithm

### DIFF
--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -169,3 +169,18 @@
   month = jun,
   pages = {4733–4736}
 }
+
+@article{Ginelli2007,
+  title = {Characterizing Dynamics with Covariant Lyapunov Vectors},
+  author = {Ginelli, F. and Poggi, P. and Turchi, A. and Chat\'e, H. and Livi, R. and Politi, A.},
+  journal = {Phys. Rev. Lett.},
+  volume = {99},
+  issue = {13},
+  pages = {130601},
+  numpages = {4},
+  year = {2007},
+  month = sep,
+  publisher = {American Physical Society},
+  doi = {10.1103/PhysRevLett.99.130601},
+  url = {https://link.aps.org/doi/10.1103/PhysRevLett.99.130601}
+}

--- a/docs/src/lyapunovs.md
+++ b/docs/src/lyapunovs.md
@@ -261,3 +261,123 @@ axislegend(ax, position = :rb, nbanks = 2,labelsize = 18)
 fig
 ```
 
+## Covariant Lyapunov Vectors
+Covariant Lyapunov vectors (CLVs) are tangent vectors of a dynamical system corresponding to the directions of contraction and expansion described by the Lyapunov exponents. In 2007, Ginelli et al. [Ginelli2007](@cite) introduced a numerical method for computing CLVs, based on the Benettin method used for computing Lyapunov exponents. We do not currently implement the alternative algorithm from the 2007 Wolfe and Samelson paper.
+
+Note that the most non-central directions converge first, and the least expanding/contracting directions converge last. In particular, the most contracting direction converges first in the forward pass, and the most expanding direction converges first in the backward pass (both passes are computed in `clv()`). To see if you're getting the correct CLVs, you can check the Lyapunov exponents of the computed CLVs against a much longer trajectory using `lyapunovspectrum`, and in continuous-time systems you can check that the CLV corresponding to the flow direction is parallel to the flow direction at each point in the trajectory; if not, try the following:
+
+- Use a different integrator
+- Increase the length of forward or backward transients
+- Decrease the timestep size
+- Increase the orthonormalization/QR frequency by decreasing `Δt`
+
+```@docs
+clv
+```
+
+### Example: Discrete-time CLVs on the Hénon attractor
+
+Here we visualize the covariant Lyapunov vectors on the chaotic [Hénon attractor](https://en.wikipedia.org/wiki/H%C3%A9non_map). The expanding direction (first CLV) is shown in red, and the contracting direction (second CLV) is shown in blue.
+
+```@example MAIN
+using ChaosTools, CairoMakie
+
+henon_rule(x, p, n) = SVector{2}(1.0 - p[1]*x[1]^2 + x[2], p[2]*x[1])
+ds = DeterministicIteratedMap(henon_rule, zeros(2), [1.4, 0.3])
+
+# Compute CLVs (this also gives us the trajectory points in result.x)
+result = clv(ds, 3000; Ttr = 1000, Ttr_bkw = 200)
+
+# Extract trajectory points from CLV result
+xs = [pt[1] for pt in result.x]
+ys = [pt[2] for pt in result.x]
+
+fig = Figure()
+ax = Axis(fig[1, 1]; xlabel = L"x", ylabel = L"y")
+
+# Plot the attractor as black points
+scatter!(ax, xs, ys; color = :black, markersize = 2)
+
+# Plot CLV arrows at every 80th point
+arrow_scale = 0.15
+for i in 1:80:length(result.x)
+    x, y = result.x[i]
+    # First CLV (expanding direction) in red
+    v1 = result.V[i][:, 1]
+    arrows!(ax, [x], [y], [arrow_scale * v1[1]], [arrow_scale * v1[2]];
+        color = :red, linewidth = 1.5, arrowsize = 8)
+    # Second CLV (contracting direction) in blue
+    v2 = result.V[i][:, 2]
+    arrows!(ax, [x], [y], [arrow_scale * v2[1]], [arrow_scale * v2[2]];
+        color = :blue, linewidth = 1.5, arrowsize = 8)
+end
+
+# Manual legend with colored line elements (Makie doesn't propagate colors from `arrows!` to the legend)
+Legend(fig[1, 2],
+    [LineElement(color = :red, linewidth = 5),
+     LineElement(color = :blue, linewidth = 5)],
+    ["Expansion", "Contraction"])
+
+fig
+```
+
+Around the middle of the attractor where the greatest "bending" or folding takes place, we can see that the contracting and expanding directions become very close to parallel. This indicates the existence of homoclinic tangencies, suggesting that small perturbations of the system dynamics can produce stable periodic orbits.
+
+### Example: Continuous-time CLVs on the Lorenz attractor
+
+For continuous-time systems like the Lorenz system, CLVs can be computed in the same way. Here we visualize all three CLVs: the expanding direction (red), the neutral direction along the flow (green), and the contracting direction (blue).
+
+```@example MAIN
+using ChaosTools, CairoMakie
+
+function lorenz_rule(u, p, t)
+    σ, ρ, β = p
+    return SVector{3}(σ*(u[2]-u[1]), u[1]*(ρ-u[3]) - u[2], u[1]*u[2] - β*u[3])
+end
+
+ds = CoupledODEs(lorenz_rule, [1.0, 0.0, 0.0], [10.0, 28.0, 8/3]; diffeq = (reltol = 1e-9, abstol = 1e-9))
+
+# Generate a dense trajectory for plotting the attractor
+traj = trajectory(ds, 200; Ttr = 200, Δt = 0.01)[1]
+
+# Compute CLVs
+result = clv(ds, 500; Ttr = 1_000, Ttr_bkw = 1_000, Δt = 0.05)
+
+fig = Figure()
+ax = Axis3(fig[1, 1];
+    xlabel = L"x",
+    ylabel = L"y",
+    zlabel = L"z",
+    azimuth = 5π/7,
+    elevation = π/8
+)
+
+# Plot the attractor from the dense trajectory
+lines!(ax, traj[:, 1], traj[:, 2], traj[:, 3]; color = :gray60, linewidth = 0.5)
+
+# Plot CLV arrows at a few points
+arrow_scale = 5.0
+for i in 1:30:length(result.x)
+    x, y, z = result.x[i]
+    # First CLV (expanding) in red
+    v1 = result.V[i][:, 1]
+    arrows!(ax, [x], [y], [z], [arrow_scale*v1[1]], [arrow_scale*v1[2]], [arrow_scale*v1[3]];
+        color = :red, linewidth = 0.01, arrowsize = 0.03)
+    # Second CLV (neutral/flow direction) in green
+    v2 = result.V[i][:, 2]
+    arrows!(ax, [x], [y], [z], [arrow_scale*v2[1]], [arrow_scale*v2[2]], [arrow_scale*v2[3]];
+        color = :green, linewidth = 0.01, arrowsize = 0.03)
+    # Third CLV (contracting) in blue
+    v3 = result.V[i][:, 3]
+    arrows!(ax, [x], [y], [z], [arrow_scale*v3[1]], [arrow_scale*v3[2]], [arrow_scale*v3[3]];
+        color = :blue, linewidth = 0.01, arrowsize = 0.03)
+end
+
+Legend(fig[1, 2],
+    [LineElement(color = :red, linewidth = 5),
+     LineElement(color = :green, linewidth = 5),
+     LineElement(color = :blue, linewidth = 5)],
+    ["Expansion", "Neutral", "Contraction"])
+
+fig
+```

--- a/src/ChaosTools.jl
+++ b/src/ChaosTools.jl
@@ -29,6 +29,7 @@ include("chaosdetection/lyapunovs/lyapunov.jl")
 include("chaosdetection/lyapunovs/EAPD.jl")
 include("chaosdetection/lyapunovs/lyapunov_from_data.jl")
 include("chaosdetection/lyapunovs/lyapunovspectrum.jl")
+include("chaosdetection/lyapunovs/lyapunovvectors.jl")
 include("chaosdetection/lyapunovs/local_growth_rates.jl")
 include("chaosdetection/gali.jl")
 include("chaosdetection/expansionentropy.jl")
@@ -40,8 +41,8 @@ import Statistics
 function linreg(x::AbstractVector, y::AbstractVector)
     mx = Statistics.mean(x)
     my = Statistics.mean(y)
-    b = Statistics.covm(x, mx, y, my)/Statistics.varm(x, mx)
-    a = my - b*mx
+    b = Statistics.covm(x, mx, y, my) / Statistics.varm(x, mx)
+    a = my - b * mx
     return a, b
 end
 

--- a/src/chaosdetection/lyapunovs/lyapunovvectors.jl
+++ b/src/chaosdetection/lyapunovs/lyapunovvectors.jl
@@ -107,7 +107,7 @@ function clv(tands::TangentDynamicalSystem, N::Int;
     # --- Phase 2: Forward pass (store Q and R for N + Ttr_bkw steps) ---
     total_store = N + Ttr_bkw
     T = eltype(current_deviations(tands))
-    StateType = typeof(current_state(tands))
+    StateType = typeof(recursivecopy(current_state(tands)))
     D = size(current_deviations(tands), 1)
     Q_history = Vector{Matrix{T}}(undef, N)           # Only store Q for kept window
     R_history = Vector{Matrix{T}}(undef, total_store) # Store R for all
@@ -133,7 +133,7 @@ function clv(tands::TangentDynamicalSystem, N::Int;
         # Store Q, state, and time for the kept window (first N steps)
         if i <= N
             Q_history[i] = copy(Q_buffer)
-            x_history[i] = current_state(tands)
+            x_history[i] = recursivecopy(current_state(tands))
             t_history[i] = current_time(tands)
         end
 

--- a/src/chaosdetection/lyapunovs/lyapunovvectors.jl
+++ b/src/chaosdetection/lyapunovs/lyapunovvectors.jl
@@ -1,0 +1,222 @@
+import LinearAlgebra
+import ProgressMeter
+export clv
+
+"""
+    clv(ds::DynamicalSystem, N, k = dimension(ds); kwargs...) → (V, λ, x, t)
+
+Compute the Covariant Lyapunov Vectors (CLVs) of `ds` using the Ginelli algorithm [^Ginelli2007].
+This is a convenience wrapper that initializes a [`TangentDynamicalSystem`](@ref) with
+automatic Jacobian computation and then calls `clv(tands, N; kwargs...)`.
+
+To use a hand-coded Jacobian, create a [`TangentDynamicalSystem`](@ref) manually and call
+the lower-level method directly.
+
+See [`clv(::TangentDynamicalSystem, ...)`](@ref) for the full documentation, keyword arguments,
+and algorithm description.
+
+See also [`lyapunovspectrum`](@ref), [`lyapunov`](@ref).
+
+[^Ginelli2007]: F. Ginelli *et al.*, Phys. Rev. Lett. **99**, 130601 (2007)
+"""
+function clv(ds::CoreDynamicalSystem, N, k=dimension(ds); kwargs...)
+    tands = TangentDynamicalSystem(ds; k)
+    return clv(tands, N; kwargs...)
+end
+
+"""
+    clv(tands::TangentDynamicalSystem, N::Int; kwargs...) → (V, λ, x, t)
+
+Compute the Covariant Lyapunov Vectors (CLVs) using the Ginelli algorithm [^Ginelli2007].
+CLVs are intrinsic, norm-independent vectors that characterize the local stability directions
+of a dynamical system, in contrast to Gram-Schmidt vectors which depend on the chosen norm.
+
+Use this method for looping over different initial conditions or parameters by
+calling [`reinit!`](@ref) on `tands`, or when you have a hand-coded Jacobian.
+
+## Returns
+
+A named tuple `(V, λ, x, t)` where:
+- `V::Vector{Matrix}`: CLVs at each stored time step. `V[i]` is a `D×k` matrix whose columns
+  are the `k` CLVs at time `t[i]`, ordered from most expanding to most contracting.
+- `λ::Vector`: Lyapunov exponents (growth rates along CLVs), ordered from largest to smallest.
+- `x::Vector`: State vectors at each stored time step.
+- `t::Vector`: Time stamps corresponding to each stored CLV snapshot.
+
+## Keyword arguments
+
+* `u0 = current_state(tands)`: Initial state.
+* `Ttr = 0`: Forward transient time to evolve before storing CLVs.
+  Both the system and deviation vectors are evolved during this time.
+* `Ttr_bkw = N`: Backward transient steps. More steps improve convergence of
+  the backward pass but increase computation time.
+* `Δt = 1`: Time between successive orthonormalization steps.
+  For continuous systems this is approximate.
+* `show_progress = false`: Display a progress bar.
+
+## Algorithm
+
+The Ginelli algorithm computes CLVs via a two-pass procedure:
+
+1. **Forward pass**: Evolve the tangent dynamics, applying QR decomposition at each step
+   to obtain the Gram-Schmidt (GS) orthonormal basis Q and upper triangular R matrices.
+   To ensure uniqueness, sign corrections are applied so that R has positive diagonal
+   entries: if `R[j,j] < 0`, the j-th *row* of R is negated, and correspondingly the
+   j-th *column* of Q is negated. Store Q and R for `N` steps (plus `Ttr_bkw` additional
+   steps for backward convergence).
+
+2. **Backward pass**: Initialize a coefficient matrix C = I. Iterate backward through
+   the stored R matrices, computing `C ← R⁻¹ C` and normalizing columns at each step.
+   The physical CLVs are then `V = Q C`.
+
+The CLVs have the key property of being *covariant*: if V(t) is a CLV at time t,
+then after evolution by the tangent dynamics, the resulting vector is parallel to V(t+Δt).
+
+[^Ginelli2007]: F. Ginelli *et al.*, Phys. Rev. Lett. **99**, 130601 (2007)
+"""
+function clv(tands::TangentDynamicalSystem, N::Int;
+    Δt::Real=1, Ttr::Real=0, Ttr_bkw::Int=N,
+    show_progress=false, u0=current_state(tands),
+)
+    reinit!(tands, u0)
+    k = size(current_deviations(tands), 2)
+
+    # Set up progress bar
+    total_steps = (Ttr > 0 ? ceil(Int, Ttr / Δt) : 0) + N + Ttr_bkw + N
+    progress = ProgressMeter.Progress(total_steps;
+        desc="CLV computation: ", dt=1.0, enabled=show_progress
+    )
+    step_count = 0
+
+    # --- Phase 1: Forward transient (converge GS directions, discard R) ---
+    D = size(current_deviations(tands), 1)
+    T = eltype(current_deviations(tands))
+    Q_transient = Matrix{T}(undef, D, k)
+    R_transient = Matrix{T}(undef, k, k)
+    if Ttr > 0
+        t0 = current_time(tands)
+        while current_time(tands) < t0 + Ttr
+            step!(tands, Δt)
+            _thin_qr_positive_diagonal!(Q_transient, R_transient, current_deviations(tands), k)
+            set_deviations!(tands, Q_transient)
+            step_count += 1
+            ProgressMeter.update!(progress, step_count)
+        end
+    end
+
+    # --- Phase 2: Forward pass (store Q and R for N + Ttr_bkw steps) ---
+    total_store = N + Ttr_bkw
+    T = eltype(current_deviations(tands))
+    StateType = typeof(current_state(tands))
+    D = size(current_deviations(tands), 1)
+    Q_history = Vector{Matrix{T}}(undef, N)           # Only store Q for kept window
+    R_history = Vector{Matrix{T}}(undef, total_store) # Store R for all
+    x_history = Vector{StateType}(undef, N)           # Store states for kept window
+    t_history = Vector{Float64}(undef, N)
+
+    # Pre-allocate buffers for QR decomposition
+    Q_buffer = Matrix{T}(undef, D, k)
+    R_buffer = Matrix{T}(undef, k, k)
+
+    t_start = current_time(tands)
+    for i in 1:total_store
+        step!(tands, Δt)
+        # Compute thin QR with positive diagonal (sign-corrected Q and R)
+        _thin_qr_positive_diagonal!(Q_buffer, R_buffer, current_deviations(tands), k)
+
+        # Set the sign-corrected Q as the new deviations
+        set_deviations!(tands, Q_buffer)
+
+        # Store R for backward pass (must copy since we reuse buffer)
+        R_history[i] = copy(R_buffer)
+
+        # Store Q, state, and time for the kept window (first N steps)
+        if i <= N
+            Q_history[i] = copy(Q_buffer)
+            x_history[i] = current_state(tands)
+            t_history[i] = current_time(tands)
+        end
+
+        step_count += 1
+        ProgressMeter.update!(progress, step_count)
+    end
+
+    # Compute Lyapunov exponents from R diagonal elements
+    λ = zeros(T, k)
+    for i in 1:total_store
+        for j in 1:k
+            @inbounds λ[j] += log(R_history[i][j, j])  # Already positive from extraction
+        end
+    end
+    t_total = current_time(tands) - t_start
+    λ ./= t_total
+
+    # --- Phase 3: Backward pass (compute CLVs as V = Q * C) ---
+    C = Matrix{T}(LinearAlgebra.I, k, k)  # Coefficient matrix
+    V_history = Vector{Matrix{T}}(undef, N)
+
+    # First, traverse the backward transient (discard, just evolve C)
+    for i in total_store:-1:(N+1)
+        C = LinearAlgebra.UpperTriangular(R_history[i]) \ C
+        _normalize_columns!(C)
+        step_count += 1
+        ProgressMeter.update!(progress, step_count)
+    end
+
+    # Now traverse the kept window, computing physical CLVs
+    for i in N:-1:1
+        V_history[i] = Q_history[i] * C
+
+        # Prepare C for the next (earlier) time step
+        C = LinearAlgebra.UpperTriangular(R_history[i]) \ C
+        _normalize_columns!(C)
+        step_count += 1
+        ProgressMeter.update!(progress, step_count)
+    end
+
+    return (V=V_history, λ=λ, x=x_history, t=t_history)
+end
+
+# --- Helper functions ---
+
+"""
+Compute thin QR decomposition with positive diagonal on R, storing results in pre-allocated buffers.
+This ensures uniqueness of the QR decomposition for CLV computation.
+Q_out is m×k and R_out is k×k.
+Sign flips are applied to both Q columns and R rows to ensure R[j,j] > 0.
+"""
+function _thin_qr_positive_diagonal!(Q_out::AbstractMatrix, R_out::AbstractMatrix, Z::AbstractMatrix, k::Int)
+    F = LinearAlgebra.qr(Z)
+    m = size(Z, 1)
+    # Copy into pre-allocated buffers
+    Q_full = F.Q
+    R_full = F.R
+    @inbounds for j in 1:k
+        for i in 1:m
+            Q_out[i, j] = Q_full[i, j]
+        end
+        for i in 1:k
+            R_out[i, j] = R_full[i, j]
+        end
+    end
+    # Apply sign corrections
+    @inbounds for j in 1:k
+        if real(R_out[j, j]) < 0
+            @views R_out[j, :] .*= -1
+            @views Q_out[:, j] .*= -1
+        end
+    end
+    return nothing
+end
+
+"""
+Normalize each column of matrix C to unit length.
+"""
+function _normalize_columns!(C::AbstractMatrix)
+    @inbounds for j in axes(C, 2)
+        col = @view C[:, j]
+        s = LinearAlgebra.norm(col)
+        col ./= s
+    end
+    return nothing
+end

--- a/test/chaosdetection/lyapunovs.jl
+++ b/test/chaosdetection/lyapunovs.jl
@@ -4,13 +4,13 @@ import Statistics
 
 # Creation of a trivial system with one coordinate going to infinity
 # and the other to zero. Lyapunov exponents are known analytically
-trivial_rule(x, p, n) = SVector{2}(p[1]*x[1], p[2]*x[2])
+trivial_rule(x, p, n) = SVector{2}(p[1] * x[1], p[2] * x[2])
 function trivial_rule_iip(dx, x, p, n)
     dx .= trivial_rule(x, p, n)
     return
 end
-trivial_jac(x, p, n) = SMatrix{2, 2}(p[1], 0, 0, p[2])
-trivial_jac_iip(J, x, p, n) = (J[1,1] = p[1]; J[2,2] = p[2]; nothing)
+trivial_jac(x, p, n) = SMatrix{2,2}(p[1], 0, 0, p[2])
+trivial_jac_iip(J, x, p, n) = (J[1, 1] = p[1]; J[2, 2] = p[2]; nothing)
 
 u0 = ones(2)
 p0_disc = [1.1, 0.8]
@@ -26,24 +26,24 @@ p0_cont = [0.1, -0.4]
     ds = SystemType(rule, u0, p0)
 
     # Be careful here to not integrate too long because states become infinite
-    λmax = lyapunov(ds, 100; Δt = 1, d0 = 1e-3)
+    λmax = lyapunov(ds, 100; Δt=1, d0=1e-3)
 
-    @test isapprox(λmax, lyapunovs[1]; atol = 0, rtol = 0.05)
+    @test isapprox(λmax, lyapunovs[1]; atol=0, rtol=0.05)
 
     @testset "tangent IAD=$(IAD)" for IAD in (true, false)
         if IAD
             Jf = IIP ? trivial_jac_iip : trivial_jac
-            tands = TangentDynamicalSystem(ds; J = Jf)
-            spec = lyapunovspectrum(tands, 100; Δt = 1)
-            spec1 = lyapunovspectrum(TangentDynamicalSystem(ds; k = 1, J = Jf), 100; Δt = 1)
+            tands = TangentDynamicalSystem(ds; J=Jf)
+            spec = lyapunovspectrum(tands, 100; Δt=1)
+            spec1 = lyapunovspectrum(TangentDynamicalSystem(ds; k=1, J=Jf), 100; Δt=1)
         else
-            spec = lyapunovspectrum(ds, 100; Δt = 1)
-            spec1 = lyapunovspectrum(ds, 100, 1; Δt = 1)
+            spec = lyapunovspectrum(ds, 100; Δt=1)
+            spec1 = lyapunovspectrum(ds, 100, 1; Δt=1)
         end
 
-        @test isapprox(spec[1], lyapunovs[1]; atol = 0, rtol = 1e-3)
-        @test isapprox(spec1[1], lyapunovs[1]; atol = 0, rtol = 1e-3)
-        @test isapprox(spec[2], lyapunovs[2]; atol = 0, rtol = 1e-3)
+        @test isapprox(spec[1], lyapunovs[1]; atol=0, rtol=1e-3)
+        @test isapprox(spec1[1], lyapunovs[1]; atol=0, rtol=1e-3)
+        @test isapprox(spec[2], lyapunovs[2]; atol=0, rtol=1e-3)
     end
 
 end
@@ -56,15 +56,17 @@ end
 
     @testset "Lorenz stable" begin
         function lorenz_rule(u, p, t)
-            σ = p[1]; ρ = p[2]; β = p[3]
-            du1 = σ*(u[2]-u[1])
-            du2 = u[1]*(ρ-u[3]) - u[2]
-            du3 = u[1]*u[2] - β*u[3]
+            σ = p[1]
+            ρ = p[2]
+            β = p[3]
+            du1 = σ * (u[2] - u[1])
+            du2 = u[1] * (ρ - u[3]) - u[2]
+            du3 = u[1] * u[2] - β * u[3]
             return SVector{3}(du1, du2, du3)
         end
 
-        ds = CoupledODEs(lorenz_rule, fill(10.0, 3), [10, 20, 8/3])
-        @test lyapunov(ds, 2000, Ttr = 100) ≈ 0 atol = 1e-3
+        ds = CoupledODEs(lorenz_rule, fill(10.0, 3), [10, 20, 8 / 3])
+        @test lyapunov(ds, 2000, Ttr=100) ≈ 0 atol = 1e-3
     end
 end
 
@@ -72,10 +74,10 @@ end
     f(u, p, t) = 0.9u
     ds = DiscreteDynamicalSystem(f, rand(SVector{3}), nothing)
     λ1 = lyapunov(ds, 10000)
-    @test isapprox(λ1, log(0.9); rtol = 1e-3)
+    @test isapprox(λ1, log(0.9); rtol=1e-3)
 end
 
-henon_rule(x, p, n) = SVector{2}(1.0 - p[1]*x[1]^2 + x[2], p[2]*x[1])
+henon_rule(x, p, n) = SVector{2}(1.0 - p[1] * x[1]^2 + x[2], p[2] * x[1])
 henon() = DeterministicIteratedMap(henon_rule, zeros(2), [1.4, 0.3])
 
 @testset "Lyapunov from data" begin
@@ -86,7 +88,7 @@ henon() = DeterministicIteratedMap(henon_rule, zeros(2), [1.4, 0.3])
     @testset "$meth, $di" for meth in [NeighborNumber(1), NeighborNumber(4), WithinRange(0.01)], di in [Euclidean(), FirstElement()]
         R = embed(x, 4, 1)
         E = lyapunov_from_data(R, ks,
-        refstates = 1:1000, distance=di, ntype=meth)
+            refstates=1:1000, distance=di, ntype=meth)
         λ = ChaosTools.linreg(ks, E)[2]
         @test 0.3 < λ < 0.5
     end
@@ -95,22 +97,151 @@ end
 @testset "Local growth rates" begin
     # input arguments
     ds = henon()
-    points, tvec = trajectory(ds, 2000; Ttr = 100)
+    points, tvec = trajectory(ds, 2000; Ttr=100)
     λ = lyapunov(ds, 10_000)
     using Random: seed!
     seed!(1234151)
 
-    λlocal = local_growth_rates(ds, points; Δt = 20, S = 20, e = 1e-12)
+    λlocal = local_growth_rates(ds, points; Δt=20, S=20, e=1e-12)
 
     @test size(λlocal) == (2001, 20)
     @test all(λlocal .< 1.0)
     mean_local = Statistics.mean(λlocal)
-    @test λ-0.1 ≤ mean_local ≤ λ+0.1
+    @test λ - 0.1 ≤ mean_local ≤ λ + 0.1
 end
 
 @testset "testSuccessfulStep" begin
     u0 = [NaN, 0]
     p0 = [0.1, -0.4]
     ds = CoupledODEs(trivial_rule, u0, p0)
-    @test isnan(lyapunov(ds, 10; Ttr = 0, Δt = 0.5))
+    @test isnan(lyapunov(ds, 10; Ttr=0, Δt=0.5))
+end
+
+# --- Covariant Lyapunov Vectors (CLV) tests ---
+
+@testset "CLV diagonal system" begin
+    # For diagonal systems, CLVs should be coordinate axis vectors
+    @testset "IDT=$(IDT), IIP=$(IIP)" for IDT in (true, false), IIP in (false, true)
+        SystemType = IDT ? DeterministicIteratedMap : CoupledODEs
+        rule = IIP ? trivial_rule_iip : trivial_rule
+        p0 = IDT ? p0_disc : p0_cont
+
+        ds = SystemType(rule, u0, p0)
+        result = clv(ds, 20; Ttr=50, Ttr_bkw=50)
+
+        # Check that final CLVs are close to coordinate axes
+        V_final = result.V[end]
+        for j in 1:2
+            v = V_final[:, j]
+            # CLV should be approximately a unit vector along one axis
+            @test maximum(abs.(v)) ≈ 1.0 atol = 1e-4
+            # Only one component should be significant
+            @test count(x -> abs(x) > 0.5, v) == 1
+        end
+    end
+end
+
+@testset "CLV Lyapunov consistency" begin
+    # CLV-computed Lyapunov exponents should match lyapunovspectrum
+    @testset "Hénon map" begin
+        ds = henon()
+        N = 100
+        result = clv(ds, N; Ttr=200, Ttr_bkw=100)
+        λ_spec = lyapunovspectrum(ds, N + 100; Ttr=200)
+
+        @test result.λ[1] ≈ λ_spec[1] rtol = 0.05
+        @test result.λ[2] ≈ λ_spec[2] rtol = 0.05
+    end
+
+    @testset "Lorenz system" begin
+        function lorenz_rule(u, p, t)
+            σ, ρ, β = p
+            return SVector{3}(
+                σ * (u[2] - u[1]),
+                u[1] * (ρ - u[3]) - u[2],
+                u[1] * u[2] - β * u[3]
+            )
+        end
+        ds = CoupledODEs(lorenz_rule, [1.0, 0.0, 0.0], [10.0, 28.0, 8 / 3])
+
+        N = 50
+        result = clv(ds, N; Ttr=20, Ttr_bkw=50, Δt=0.5)
+        λ_spec = lyapunovspectrum(ds, N + 50; Ttr=20, Δt=0.5)
+
+        @test result.λ[1] ≈ λ_spec[1] rtol = 0.1
+        @test result.λ[2] ≈ λ_spec[2] atol = 0.1  # Near-zero exponent
+        @test result.λ[3] ≈ λ_spec[3] rtol = 0.1
+    end
+end
+
+@testset "CLV covariance property" begin
+    import LinearAlgebra: dot, norm
+
+    @testset "Hénon map covariance" begin
+        ds = henon()
+        N = 50
+        result = clv(ds, N; Ttr=500, Ttr_bkw=200)
+
+        # Get the Jacobian function (note: SMatrix uses column-major order)
+        # Hénon Jacobian: [[-2ax, 1], [b, 0]], but SMatrix fills column-by-column
+        henon_jac(x, p, n) = SMatrix{2,2}(-2 * p[1] * x[1], p[2], 1.0, 0.0)
+
+        # Use the states returned by clv()
+        p = current_parameters(ds)
+
+        # Check covariance for the first CLV (most expanding direction)
+        # The second CLV requires much longer transients to converge
+        num_tests_pass = 0
+        for i in 1:(N-1)
+            J = henon_jac(result.x[i], p, 0)
+            v_evolved = J * result.V[i][:, 1]
+            v_next = result.V[i+1][:, 1]
+            # Check they are parallel: |cos(angle)| ≈ 1
+            cosθ = abs(dot(v_evolved, v_next) / (norm(v_evolved) * norm(v_next)))
+            if cosθ > 0.999
+                num_tests_pass += 1
+            end
+        end
+        # All covariance checks should pass with high precision
+        @test num_tests_pass == N - 1
+    end
+end
+
+@testset "CLV neutral direction (flow alignment)" begin
+    # This test is very important for ensuring that the CLVs are being computed correctly.
+    # If this test fails, you're probably getting bogus CLVs.
+    import LinearAlgebra: dot, norm
+
+    # For continuous-time systems, the neutral CLV (λ ≈ 0) should align with the flow direction
+    @testset "Lorenz neutral CLV aligns with flow" begin
+        function lorenz_rule(u, p, t)
+            σ, ρ, β = p
+            return SVector{3}(σ * (u[2] - u[1]), u[1] * (ρ - u[3]) - u[2], u[1] * u[2] - β * u[3])
+        end
+
+        ds = CoupledODEs(lorenz_rule, [1.0, 0.0, 0.0], [10.0, 28.0, 8 / 3])
+        p = current_parameters(ds)
+
+        # Compute CLVs with sufficient transients for convergence
+        result = clv(ds, 100; Ttr=1_000, Ttr_bkw=1_000, Δt=0.1)
+
+        # Check that the neutral CLV (second one) aligns with the flow vector
+        num_aligned = 0
+        for i in 1:length(result.x)
+            x = result.x[i]
+            # Flow direction = f(x) / |f(x)|
+            flow = lorenz_rule(x, p, 0.0)
+            flow_normalized = flow / norm(flow)
+            # Neutral CLV is the second one (λ ≈ 0)
+            v_neutral = result.V[i][:, 2]
+            v_neutral_normalized = v_neutral / norm(v_neutral)
+            # Check alignment: |cos(angle)| ≈ 1
+            cosθ = abs(dot(flow_normalized, v_neutral_normalized))
+            if cosθ > 0.99
+                num_aligned += 1
+            end
+        end
+        # At least 95% should be well-aligned
+        @test num_aligned >= 0.95 * length(result.x)
+    end
 end


### PR DESCRIPTION
## Add Covariant Lyapunov Vectors (CLV) via Ginelli algorithm

This PR implements the `clv()` function for computing Covariant Lyapunov Vectors using the forward-backward Ginelli algorithm (Ginelli et al., Phys. Rev. Lett. 99, 130601, 2007; [arXiv](https://arxiv.org/abs/0706.0510)).

### What are CLVs?

Covariant Lyapunov Vectors are tangent vectors over a trajectory that characterize the local stability directions of a dynamical system (i.e., they are associated to the Lyapunov exponents). Unlike Gram-Schmidt vectors from the standard Lyapunov exponent computation, CLVs are covariant under the dynamics: if V(t) is a CLV at time t, then after evolution by the tangent dynamics, the resulting vector is parallel to V(t+Δt).

### API

```julia
result = clv(ds, N; Ttr=1000, Ttr_bkw=500, Δt=0.1)
# Returns named tuple:
#   V::Vector{Matrix{T}}  - CLVs at each time step (D×k matrices)
#   λ::Vector{T}          - Lyapunov exponents
#   x::Vector{StateType}  - State vectors
#   t::Vector{Float64}    - Timestamps
```

### Features

- Works with both discrete (`DeterministicIteratedMap`) and continuous (`CoupledODEs`) systems
- Supports in-place and out-of-place system definitions
- Uses `TangentDynamicalSystem` for automatic or hand-coded Jacobians
- API follows existing `lyapunovspectrum` conventions

### Tests

- Diagonal system: CLVs correctly align with coordinate axes
- Lyapunov consistency: exponents match `lyapunovspectrum` for Hénon map and Lorenz system
- Covariance property: verifies J(x)V(t) ∥ V(t+1) for Hénon map
- Neutral direction: verifies the λ≈0 CLV aligns with the flow direction for Lorenz

### Documentation

Added a new "Covariant Lyapunov Vectors" section to `lyapunovs.md` ("Chaos detection" in the docs) with:
- Full docstrings including algorithm description with paper citation
- Plotted examples showing CLVs on the Hénon and Lorenz attractors
- Convergence guidance for troubleshooting

### Performance

Benchmarks for the documentation examples (on Apple M4):

| System | Call | Time | Allocations | Memory |
|--------|------|------|-------------|--------|
| Hénon (2D discrete) | `clv(ds, 3000; Ttr=1000, Ttr_bkw=200)` | 1.29 ms | 46k | 2.6 MiB |
| Lorenz (3D continuous) | `clv(ds, 500; Ttr=1000, Ttr_bkw=1000, Δt=0.05)` | 60.8 ms | 330k | 18.3 MiB |

Type stability verified with `@code_warntype`.
